### PR TITLE
Warn when enabling socket_telemetry on unsupported platform

### DIFF
--- a/lib/puma/plugin/telemetry/config.rb
+++ b/lib/puma/plugin/telemetry/config.rb
@@ -91,7 +91,14 @@ module Puma
         end
 
         def socket_telemetry!
-          @socket_telemetry = true
+          # These structs are platform specific, and not available on macOS,
+          # for example. If they're undefined, then we cannot capture socket
+          # telemetry. We'll warn in that case.
+          if defined?(Socket::SOL_TCP) && defined?(Socket::TCP_INFO)
+            @socket_telemetry = true
+          else
+            warn("Cannot capture socket telemetry on this platform (#{RUBY_PLATFORM}); socket_telemetry is disabled.")
+          end
         end
 
         def socket_telemetry?

--- a/lib/puma/plugin/telemetry/config.rb
+++ b/lib/puma/plugin/telemetry/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'socket'
+
 module Puma
   class Plugin
     module Telemetry
@@ -97,6 +99,7 @@ module Puma
           if defined?(Socket::SOL_TCP) && defined?(Socket::TCP_INFO)
             @socket_telemetry = true
           else
+            @socket_telemetry = false
             warn("Cannot capture socket telemetry on this platform (#{RUBY_PLATFORM}); socket_telemetry is disabled.")
           end
         end

--- a/spec/integration/plugin_spec.rb
+++ b/spec/integration/plugin_spec.rb
@@ -105,6 +105,10 @@ module Puma
         end
 
         it 'logs socket telemetry' do
+          unless defined?(Socket::SOL_TCP) && defined?(Socket::TCP_INFO)
+            skip("Socket::SOL_TCP not defined on #{RUBY_PLATFORM}")
+          end
+
           threads = Array.new(2) { make_request }
 
           sleep 0.1
@@ -123,7 +127,7 @@ module Puma
           possible_lines = ['queue.backlog=1 sockets.backlog=5',
                             'queue.backlog=0 sockets.backlog=6']
 
-          expect(possible_lines.include?(line)).to eq(true)
+          expect(possible_lines).to include(line)
 
           total = line.split.sum { |kv| kv.split('=').last.to_i }
           expect(total).to eq 6

--- a/spec/integration/plugin_spec.rb
+++ b/spec/integration/plugin_spec.rb
@@ -106,7 +106,7 @@ module Puma
 
         it 'logs socket telemetry' do
           unless defined?(Socket::SOL_TCP) && defined?(Socket::TCP_INFO)
-            skip("Socket::SOL_TCP not defined on #{RUBY_PLATFORM}")
+            skip("Socket::SOL_TCP and/or Socket::TCP_INFO not defined on #{RUBY_PLATFORM}")
           end
 
           threads = Array.new(2) { make_request }

--- a/spec/puma/plugin/telemetry/config_spec.rb
+++ b/spec/puma/plugin/telemetry/config_spec.rb
@@ -18,6 +18,41 @@ module Puma
           end
         end
 
+        describe '#socket_telemetry!' do
+          context 'when TCP_INFO is available' do
+            before do
+              stub_const('Socket::SOL_TCP', 6)
+              stub_const('Socket::TCP_INFO', 11)
+            end
+
+            it 'enables socket telemetry' do
+              config.socket_telemetry!
+
+              expect(config.socket_telemetry?).to eq true
+            end
+          end
+
+          context 'when TCP_INFO is not available' do
+            before { hide_const('Socket::TCP_INFO') }
+
+            it 'warns and keeps socket telemetry disabled' do
+              expect { config.socket_telemetry! }
+                .to output(/socket_telemetry is disabled/).to_stderr
+
+              expect(config.socket_telemetry?).to eq false
+            end
+
+            it 'disables socket telemetry when previously enabled' do
+              config.socket_telemetry = true
+
+              expect { config.socket_telemetry! }
+                .to output(/socket_telemetry is disabled/).to_stderr
+
+              expect(config.socket_telemetry?).to eq false
+            end
+          end
+        end
+
         describe '#add_target' do
           context 'when built in: IO' do
             it 'adds new target' do


### PR DESCRIPTION
The structs we depend on for collecting socket telemetry (`SOL_TCP` and `TCP_INFO`) don't exist on all platforms. In such cases, these constants won't be defined, and so we should WARN users and not enabled the `socket_telemetry` option.

NOTE: On macOS, similar structs do exist: `Socket::IPPROTO_TCP` and `Socket::TCP_CONNECTION_INFO`, respectively, and we can unpack the binary info thusly:

```ruby
require 'socket'

sock = TCPSocket.new('example.com', 80)
info = sock.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_CONNECTION_INFO)

# Struct: 2x uint8 (C2), 26x uint32 (L26)
fields = info.unpack("C2L26")

tcp_connection_info = {
  tcpi_state: fields[0],
  tcpi_snd_wscale: fields[1] >> 4,
  tcpi_rcv_wscale: fields[1] & 0x0F,
  tcpi_options: fields[2],
  tcpi_flags: fields[3],
  tcpi_rto: fields[4],
  tcpi_maxseg: fields[5],
  tcpi_snd_ssthresh: fields[6],
  tcpi_snd_cwnd: fields[7],
  tcpi_snd_wnd: fields[8],
  tcpi_rcv_wnd: fields[9],
  tcpi_rttcur: fields[10],
  tcpi_srtt: fields[11],
  tcpi_rttvar: fields[12],
  tcpi_txpackets: fields[13],
  tcpi_rxpackets: fields[14],
  tcpi_txbytes: fields[15],
  tcpi_rxbytes: fields[16],
  tcpi_last_data_recv: fields[17],
  tcpi_last_ack_recv: fields[18],
  tcpi_last_data_sent: fields[19],
  tcpi_last_ack_sent: fields[20],
  tcpi_pmtu: fields[21],
  tcpi_rcv_ssthresh: fields[22],
  tcpi_snd_rexmitpack: fields[23],
  tcpi_rcv_ooopack: fields[24],
  tcpi_snd_zerowin: fields[25],
  # add more fields as needed
}

puts tcp_connection_info
```

However, macOS doesn't expose the number of unacked connections like various Linux kernels do. There is, as of now, to my knowledge, no way to get this info without using some other OS level tool.
