### PR TITLE
V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ### Changed
 - Updated gems in the lockfile
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-plugin-telemetry (1.1.4)
+    puma-plugin-telemetry (2.0.0)
       puma (< 7)
 
 GEM

--- a/lib/puma/plugin/telemetry/version.rb
+++ b/lib/puma/plugin/telemetry/version.rb
@@ -3,7 +3,7 @@
 module Puma
   class Plugin
     module Telemetry
-      VERSION = '1.1.4'
+      VERSION = '2.0.0'
     end
   end
 end


### PR DESCRIPTION
This would bump the current version to 2 because we will drop support with ruby 2.6 and 2.7, this might be a breaking change for some, so I want to communicate it explicitly 