### PR TITLE
Allow Puma 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated gems in the lockfile
+- Allow Puma 7
 
 ### Added
 - Check for support for 'ubuntu-24.04'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     puma-plugin-telemetry (1.1.4)
-      puma (< 7)
+      puma (< 8)
 
 GEM
   remote: https://rubygems.org/

--- a/puma-plugin-telemetry.gemspec
+++ b/puma-plugin-telemetry.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'puma', '< 7'
+  spec.add_dependency 'puma', '< 8'
 end


### PR DESCRIPTION
[Here's a link to the Puma 7.0 release](https://github.com/puma/puma/releases/tag/v7.0.0) which mentions breaking changes. Based on my quick analysis, these don't impact the `puma-plugin-telemetry` gem, so I'm bumping the Puma support in this gem.

Since this is blocking our upgrade to Puma 7.0, I'd also appreacing releasing a new version of `puma-plugin-telemetry` 🙏 