### PR TITLE
Emit busy_threads threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated gems in the lockfile
+- Extract metric name strings to `Puma::Plugin::Telemetry::Metrics` constants for better maintainability
 
 ### Added
 - Check for support for 'ubuntu-24.04'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-plugin-telemetry (1.1.4)
+    puma-plugin-telemetry (1.1.5)
       puma (< 7)
 
 GEM

--- a/lib/puma/plugin/telemetry/config.rb
+++ b/lib/puma/plugin/telemetry/config.rb
@@ -7,27 +7,30 @@ module Puma
       class Config
         DEFAULT_PUMA_TELEMETRY = [
           # Total booted workers.
-          'workers.booted',
+          Metrics::WORKERS_BOOTED,
 
           # Total number of workers configured.
-          'workers.total',
+          Metrics::WORKERS_TOTAL,
 
           # Current number of threads spawned.
-          'workers.spawned_threads',
+          Metrics::WORKERS_SPAWNED_THREADS,
 
           # Maximum number of threads that can run .
-          'workers.max_threads',
+          Metrics::WORKERS_MAX_THREADS,
 
           # Number of requests performed so far.
-          'workers.requests_count',
+          Metrics::WORKERS_REQUESTS_COUNT,
+
+          # Number of threads currently busy processing requests.
+          Metrics::WORKERS_BUSY_THREADS,
 
           # Number of requests waiting to be processed.
-          'queue.backlog',
+          Metrics::QUEUE_BACKLOG,
 
           # Free capacity that could be utilized, i.e. if backlog
           # is growing, and we still have capacity available, it
           # could mean that load balancing is not performing well.
-          'queue.capacity'
+          Metrics::QUEUE_CAPACITY
         ].freeze
 
         TARGETS = {

--- a/lib/puma/plugin/telemetry/data.rb
+++ b/lib/puma/plugin/telemetry/data.rb
@@ -3,16 +3,29 @@
 module Puma
   class Plugin
     module Telemetry
+      # Metric name constants for telemetry data
+      module Metrics
+        WORKERS_BOOTED = 'workers.booted'
+        WORKERS_TOTAL = 'workers.total'
+        WORKERS_SPAWNED_THREADS = 'workers.spawned_threads'
+        WORKERS_MAX_THREADS = 'workers.max_threads'
+        WORKERS_REQUESTS_COUNT = 'workers.requests_count'
+        WORKERS_BUSY_THREADS = 'workers.busy_threads'
+        QUEUE_BACKLOG = 'queue.backlog'
+        QUEUE_CAPACITY = 'queue.capacity'
+      end
+
       # Helper for working with Puma stats
       module CommonData
         TELEMETRY_TO_METHODS = {
-          'workers.booted' => :workers_booted,
-          'workers.total' => :workers_total,
-          'workers.spawned_threads' => :workers_spawned_threads,
-          'workers.max_threads' => :workers_max_threads,
-          'workers.requests_count' => :workers_requests_count,
-          'queue.backlog' => :queue_backlog,
-          'queue.capacity' => :queue_capacity
+          Metrics::WORKERS_BOOTED => :workers_booted,
+          Metrics::WORKERS_TOTAL => :workers_total,
+          Metrics::WORKERS_SPAWNED_THREADS => :workers_spawned_threads,
+          Metrics::WORKERS_MAX_THREADS => :workers_max_threads,
+          Metrics::WORKERS_REQUESTS_COUNT => :workers_requests_count,
+          Metrics::WORKERS_BUSY_THREADS => :workers_busy_threads,
+          Metrics::QUEUE_BACKLOG => :queue_backlog,
+          Metrics::QUEUE_CAPACITY => :queue_capacity
         }.freeze
 
         def initialize(stats)
@@ -52,6 +65,10 @@ module Puma
           @stats.fetch(:running, 0)
         end
 
+        def workers_busy_threads
+          @stats.fetch(:busy_threads, 0)
+        end
+
         def queue_backlog
           @stats.fetch(:backlog, 0)
         end
@@ -77,6 +94,10 @@ module Puma
 
         def workers_spawned_threads
           sum_stat(:running)
+        end
+
+        def workers_busy_threads
+          sum_stat(:busy_threads)
         end
 
         def queue_backlog

--- a/lib/puma/plugin/telemetry/targets/datadog_statsd_target.rb
+++ b/lib/puma/plugin/telemetry/targets/datadog_statsd_target.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'socket'
+
 module Puma
   class Plugin
     module Telemetry
@@ -22,8 +24,11 @@ module Puma
         #     DatadogStatsdTarget.new(client: client)
         #
         class DatadogStatsdTarget
+          TAGGED_METRICS = [Telemetry::Metrics::WORKERS_BUSY_THREADS].freeze
+
           def initialize(client:)
             @client = client
+            @hostname = Socket.gethostname
           end
 
           # We are using `gauge` metric type, which means that only the last
@@ -39,7 +44,11 @@ module Puma
           #
           def call(telemetry)
             telemetry.each do |metric, value|
-              @client.gauge(metric, value)
+              if TAGGED_METRICS.include?(metric)
+                @client.gauge(metric, value, tags: ["process:#{@hostname}"])
+              else
+                @client.gauge(metric, value)
+              end
             end
 
             @client.flush(sync: true)

--- a/lib/puma/plugin/telemetry/version.rb
+++ b/lib/puma/plugin/telemetry/version.rb
@@ -3,7 +3,7 @@
 module Puma
   class Plugin
     module Telemetry
-      VERSION = '1.1.4'
+      VERSION = '1.1.5'
     end
   end
 end

--- a/spec/integration/plugin_spec.rb
+++ b/spec/integration/plugin_spec.rb
@@ -2,6 +2,7 @@
 
 require 'timeout'
 require 'net/http'
+require 'socket'
 
 TestTakesTooLongError = Class.new(StandardError)
 
@@ -40,6 +41,7 @@ module Puma
             'workers.spawned_threads' => 1,
             'workers.max_threads' => 1,
             'workers.requests_count' => 0,
+            'workers.busy_threads' => 0,
             'queue.backlog' => 0,
             'queue.capacity' => 1
           }
@@ -74,24 +76,21 @@ module Puma
 
       context 'when dogstatsd target' do
         let(:config) { 'dogstatsd' }
-        let(:expected_telemetry) do
-          %w[
-            workers.booted:1|g
-            workers.total:1|g
-            workers.spawned_threads:1|g
-            workers.max_threads:1|g
-            workers.requests_count:0|g
-            queue.backlog:0|g
-            queue.capacity:1|g
-          ]
-        end
+        let(:hostname) { Socket.gethostname }
 
         it "doesn't crash" do
           true until (line = @server.next_line).include?('DEBUG -- : Statsd')
 
           lines = ([line.slice(/workers.*/)] + Array.new(6) { @server.next_line.strip })
 
-          expect(lines).to eq(expected_telemetry)
+          # workers.busy_threads should have hostname tag, others should not
+          expect(lines[0]).to eq('workers.booted:1|g')
+          expect(lines[1]).to eq('workers.total:1|g')
+          expect(lines[2]).to eq('workers.spawned_threads:1|g')
+          expect(lines[3]).to eq('workers.max_threads:1|g')
+          expect(lines[4]).to eq('workers.requests_count:0|g')
+          expect(lines[5]).to eq("workers.busy_threads:0|g|#process:#{hostname}")
+          expect(lines[6]).to eq('queue.backlog:0|g')
         end
       end
 

--- a/spec/puma/plugin/telemetry/data_spec.rb
+++ b/spec/puma/plugin/telemetry/data_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Puma
+  class Plugin
+    module Telemetry
+      RSpec.describe WorkerData do
+        subject(:data) { described_class.new(stats) }
+
+        describe '#workers_busy_threads' do
+          context 'when busy_threads is present' do
+            let(:stats) { { busy_threads: 5 } }
+
+            it 'returns the busy_threads value' do
+              expect(data.workers_busy_threads).to eq(5)
+            end
+          end
+
+          context 'when busy_threads is missing' do
+            let(:stats) { {} }
+
+            it 'returns 0' do
+              expect(data.workers_busy_threads).to eq(0)
+            end
+          end
+        end
+      end
+
+      RSpec.describe ClusteredData do
+        subject(:data) { described_class.new(stats) }
+
+        describe '#workers_busy_threads' do
+          context 'when workers have busy_threads' do
+            let(:stats) do
+              {
+                worker_status: [
+                  { last_status: { busy_threads: 3 } },
+                  { last_status: { busy_threads: 2 } }
+                ]
+              }
+            end
+
+            it 'sums busy_threads across all workers' do
+              expect(data.workers_busy_threads).to eq(5)
+            end
+          end
+
+          context 'when some workers are missing busy_threads' do
+            let(:stats) do
+              {
+                worker_status: [
+                  { last_status: { busy_threads: 3 } },
+                  { last_status: {} }
+                ]
+              }
+            end
+
+            it 'treats missing values as 0' do
+              expect(data.workers_busy_threads).to eq(3)
+            end
+          end
+
+          context 'when no workers have busy_threads' do
+            let(:stats) do
+              {
+                worker_status: [
+                  { last_status: {} },
+                  { last_status: {} }
+                ]
+              }
+            end
+
+            it 'returns 0' do
+              expect(data.workers_busy_threads).to eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/puma/plugin/telemetry/targets/datadog_statsd_target_spec.rb
+++ b/spec/puma/plugin/telemetry/targets/datadog_statsd_target_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'socket'
+
+module Puma
+  class Plugin
+    module Telemetry
+      module Targets
+        RSpec.describe DatadogStatsdTarget do
+          subject(:target) { described_class.new(client: client) }
+
+          let(:client) { instance_double('Datadog::Statsd') }
+
+          before do
+            allow(client).to receive(:gauge)
+            allow(client).to receive(:flush)
+            allow(Socket).to receive(:gethostname).and_return('test-host')
+          end
+
+          describe '#call' do
+            context 'with workers.busy_threads metric' do
+              let(:telemetry) { { 'workers.busy_threads' => 5 } }
+
+              it 'emits with process hostname tag' do
+                target.call(telemetry)
+                expect(client).to have_received(:gauge).with(
+                  'workers.busy_threads',
+                  5,
+                  tags: ['process:test-host']
+                )
+              end
+            end
+
+            context 'with other metrics' do
+              let(:telemetry) { { 'queue.backlog' => 10 } }
+
+              it 'emits without tags' do
+                target.call(telemetry)
+                expect(client).to have_received(:gauge).with('queue.backlog', 10)
+              end
+            end
+
+            context 'with mixed metrics' do
+              let(:telemetry) do
+                {
+                  'workers.busy_threads' => 5,
+                  'queue.backlog' => 10,
+                  'workers.spawned_threads' => 8
+                }
+              end
+
+              it 'tags only workers.busy_threads' do
+                target.call(telemetry)
+
+                expect(client).to have_received(:gauge).with(
+                  'workers.busy_threads', 5, tags: ['process:test-host']
+                )
+                expect(client).to have_received(:gauge).with('queue.backlog', 10)
+                expect(client).to have_received(:gauge).with('workers.spawned_threads', 8)
+              end
+            end
+
+            it 'flushes after emitting all metrics' do
+              target.call({ 'queue.backlog' => 1 })
+              expect(client).to have_received(:flush).with(sync: true)
+            end
+          end
+
+          describe 'hostname caching' do
+            before { target } # Force subject instantiation before assertions
+
+            it 'retrieves hostname once during initialization' do
+              expect(Socket).to have_received(:gethostname).once
+            end
+
+            it 'does not call gethostname on each call' do
+              target.call({ 'workers.busy_threads' => 1 })
+              target.call({ 'workers.busy_threads' => 2 })
+              expect(Socket).to have_received(:gethostname).once
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/puma/plugin/telemetry_spec.rb
+++ b/spec/puma/plugin/telemetry_spec.rb
@@ -21,6 +21,7 @@ module Puma
             'workers.max_threads' => 0,
             'workers.requests_count' => 0,
             'workers.spawned_threads' => 0,
+            'workers.busy_threads' => 0,
             'queue.backlog' => 0,
             'queue.capacity' => 0
           }


### PR DESCRIPTION
## Context

This PR adds a new metrics `workers.busy_threads` to count number of in-flight requests