### PR TITLE
chore(deps): PENG-1623 allow puma 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Allow puma 7 (#35)
 - Updated gems in the lockfile
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     puma-plugin-telemetry (1.1.4)
-      puma (< 7)
+      puma (< 8)
 
 GEM
   remote: https://rubygems.org/
@@ -13,13 +13,13 @@ GEM
     json (2.11.3)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.13)

--- a/puma-plugin-telemetry.gemspec
+++ b/puma-plugin-telemetry.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'puma', '< 7'
+  spec.add_dependency 'puma', '< 8'
 end

--- a/spec/integration/plugin_spec.rb
+++ b/spec/integration/plugin_spec.rb
@@ -115,18 +115,18 @@ module Puma
 
           line.strip!
 
-          # either "queue.backlog=1 sockets.backlog=5"
-          #     or "queue.backlog=0 sockets.backlog=6"
-          #
-          # depending on whenever the first 2 requests are
-          # pulled at the same time by Puma from backlog
-          possible_lines = ['queue.backlog=1 sockets.backlog=5',
-                            'queue.backlog=0 sockets.backlog=6']
+          metrics = line.split.to_h do |kv|
+            key, value = kv.split('=')
+            [key, value.to_i]
+          end
 
-          expect(possible_lines.include?(line)).to eq(true)
-
-          total = line.split.sum { |kv| kv.split('=').last.to_i }
-          expect(total).to eq 6
+          # One request is in the app, the other 6 wait either in
+          # puma's own queue or in the socket backlog. Puma 6 leaves
+          # most of them unacked in the socket backlog, puma 7 accepts
+          # them eagerly into its queue (puma/puma#3678). Assert on
+          # the total so both versions pass.
+          expect(metrics.keys).to contain_exactly('queue.backlog', 'sockets.backlog')
+          expect(metrics.values.sum).to eq 6
 
           threads.each(&:join)
         end


### PR DESCRIPTION
Relax the puma dependency from < 7 to < 8 and bump the lockfile to puma 7.2.1 so CI exercises puma 7.

Puma 7 accepts pending connections into its internal queue eagerly (puma/puma#3678), where puma 6 left them unacked in the kernel socket backlog. The socket telemetry integration spec asserted the puma 6 distribution; it now asserts the total across queue.backlog and sockets.backlog, which passes on both puma 6.6.1 and 7.2.1 (verified on Linux).

Supersedes #35.