### PR TITLE
chore(release): bump version to 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.5]
 
 ### Changed
 - Allow puma 7 (#35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.1.5]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.5]
 
 ### Changed
-- Allow puma 7 (#35)
+- Allow puma 7 (#40)
 - Updated gems in the lockfile
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-plugin-telemetry (1.1.4)
+    puma-plugin-telemetry (1.1.5)
       puma (< 8)
 
 GEM

--- a/lib/puma/plugin/telemetry/version.rb
+++ b/lib/puma/plugin/telemetry/version.rb
@@ -3,7 +3,7 @@
 module Puma
   class Plugin
     module Telemetry
-      VERSION = '1.1.4'
+      VERSION = '1.1.5'
     end
   end
 end


### PR DESCRIPTION
## Description

Version bump for the 1.1.5 release, which ships the relaxed puma constraint (`< 8`) from #40.

### Changes

- `lib/puma/plugin/telemetry/version.rb`: 1.1.4 → 1.1.5
- `CHANGELOG.md`: retitle the Unreleased section to 1.1.5
- `Gemfile.lock`: gem self-version refresh

## Release steps after merge

Push a `v1.1.5` tag on the merge commit — the `release` workflow job publishes the gem to rubygems using the AWS-vaulted credentials.

## Testing

- Full suite + RuboCop green on Linux (ruby 3.3) against puma 7.2.1

Refs #36.