### PR TITLE
chore(deps): allow puma 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [Unreleased]
+
+### Changed
+- Allow puma 8
+
 ## [1.1.5]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [Unreleased]
-
 ### Changed
 - Allow puma 8
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     puma-plugin-telemetry (1.1.5)
-      puma (< 8)
+      puma (< 9)
 
 GEM
   remote: https://rubygems.org/
@@ -19,7 +19,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    puma (7.2.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.13)

--- a/puma-plugin-telemetry.gemspec
+++ b/puma-plugin-telemetry.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'puma', '< 8'
+  spec.add_dependency 'puma', '< 9'
 end


### PR DESCRIPTION
## Description

Relaxes the puma dependency from `< 8` to `< 9` and bumps the lockfile to puma 8.0.2 so CI exercises puma 8 across the matrix.

Puma 8 keeps the Ruby >= 3.0 floor, so the build matrix is unchanged. I reviewed the [8.0 upgrade guide](https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md) — none of the breaking changes (IPv6 default bind, `before_thread_start` arity, SIGPWR trapping, stricter 413/501 handling, `fork_worker` restart order) touch this plugin's API surface (`Puma.stats` and socket options).

Note: puma 8.0.2 also contains the upstream fixes for the PROXY-protocol CVEs (GHSA-qpgp-93vx-g8v8, GHSA-2vqw-3mp8-cgmx), so apps can take either the 7.2.1 or 8.x route through this constraint.

## Testing

Full suite + RuboCop on Linux (ruby 3.3):
- puma **8.0.2**: 26 examples, 0 failures
- puma **7.2.1**: 26 examples, 0 failures (regression)
- puma **6.6.1**: 26 examples, 0 failures (regression)

The socket telemetry spec's total-based assertion (from #40) holds unchanged under puma 8's accept behavior.