### PR TITLE
chore(release): bump version to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [Unreleased]
+## [1.1.6]
 
 ### Changed
-- Allow puma 8
+- Allow puma 8 (#42)
 
 ## [1.1.5]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-plugin-telemetry (1.1.5)
+    puma-plugin-telemetry (1.1.6)
       puma (< 9)
 
 GEM

--- a/lib/puma/plugin/telemetry/version.rb
+++ b/lib/puma/plugin/telemetry/version.rb
@@ -3,7 +3,7 @@
 module Puma
   class Plugin
     module Telemetry
-      VERSION = '1.1.5'
+      VERSION = '1.1.6'
     end
   end
 end


### PR DESCRIPTION
## Description

Version bump for the 1.1.6 release, which ships the relaxed puma constraint (`< 9`, puma 8 support) from #42.

Stacked on #42 — its base is the `chore/allow-puma-8` branch, so only the release mechanics show in this diff. After #42 merges, this PR retargets to `main` automatically.

### Changes

- `lib/puma/plugin/telemetry/version.rb`: 1.1.5 → 1.1.6
- `CHANGELOG.md`: retitle the Unreleased section to 1.1.6
- `Gemfile.lock`: gem self-version refresh

## Depends on

- [ ] #42

## Release steps after both merge

Push a `v1.1.6` tag on the merge commit — the `create`-event workflow run publishes to rubygems (the `push`-event run for the tag will show release as skipped; that's expected). Then create the GitHub Release: `gh release create v1.1.6 --title v1.1.6 --generate-notes`.

## Testing

- Full suite + RuboCop green on Linux (ruby 3.3) against puma 8.0.2