### PR TITLE
fix: stop telemetry runner on puma shutdown

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+
+Metrics/ClassLength:
+  Exclude:
+    - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Stop the telemetry runner when puma shuts down or when the target IO stream is closed. This prevents `IOError: closed stream` errors during shutdown (#31)
-- Log target errors with `unknown_error` instead of `error`, so a failed publish does not make puma exit (#31)
+- Stop the telemetry runner when puma shuts down or when the target IO stream is closed. This prevents `IOError: closed stream` errors during shutdown (#31, #45)
+- Log target errors with `unknown_error` instead of `error`, so a failed publish does not make puma exit (#31, #45)
 
 ## [1.1.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stop the telemetry runner when puma shuts down or when the target IO stream is closed. This prevents `IOError: closed stream` errors during shutdown (#31)
+- Log target errors with `unknown_error` instead of `error`, so a failed publish does not make puma exit (#31)
+
 ## [1.1.6]
 
 ### Changed

--- a/lib/puma/plugin/telemetry.rb
+++ b/lib/puma/plugin/telemetry.rb
@@ -64,6 +64,7 @@ module Puma
       module PluginInstanceMethods
         def start(launcher)
           @launcher = launcher
+          @stopped = false
 
           unless Puma::Plugin::Telemetry.config.enabled?
             log_writer.log 'plugin=telemetry msg="disabled, exiting..."'
@@ -79,13 +80,8 @@ module Puma
           loop do
             break if stopped?
 
-            publish
-          rescue IOError, Errno::EPIPE
-            # Puma closes the IO streams during shutdown, stop publishing
-            break
-          rescue StandardError => e
-            log_writer.unknown_error(e, nil, 'plugin=telemetry')
-          ensure
+            break unless try_publish
+
             sleep Puma::Plugin::Telemetry.config.frequency
           end
         end
@@ -115,10 +111,28 @@ module Puma
           end
         end
 
+        def try_publish
+          publish
+          true
+        rescue IOError, Errno::EPIPE
+          # Puma closes the IO streams during shutdown, stop publishing
+          log_safely 'plugin=telemetry msg="IO stream closed, stopping the runner"'
+          false
+        rescue StandardError => e
+          log_writer.unknown_error(e, nil, 'plugin=telemetry')
+          true
+        end
+
         def publish
           log_writer.debug 'plugin=telemetry msg="publish"'
 
           call(Puma::Plugin::Telemetry.build(@launcher))
+        end
+
+        def log_safely(message)
+          log_writer.log(message)
+        rescue IOError, Errno::EPIPE
+          nil
         end
 
         def log_writer

--- a/lib/puma/plugin/telemetry.rb
+++ b/lib/puma/plugin/telemetry.rb
@@ -72,24 +72,30 @@ module Puma
 
           log_writer.log 'plugin=telemetry msg="enabled, setting up runner..."'
 
-          in_background do
-            sleep Puma::Plugin::Telemetry.config.initial_delay
-            run!
-          end
+          setup_runner
         end
 
         def run!
           loop do
-            log_writer.debug 'plugin=telemetry msg="publish"'
+            break if stopped?
 
-            call(Puma::Plugin::Telemetry.build(@launcher))
-          rescue Errno::EPIPE
-            # Occurs when trying to output to STDOUT while puma is shutting down
+            publish
+          rescue IOError, Errno::EPIPE
+            # Puma closes the IO streams during shutdown, stop publishing
+            break
           rescue StandardError => e
-            log_writer.error "plugin=telemetry err=#{e.class} msg=#{e.message.inspect}"
+            log_writer.unknown_error(e, nil, 'plugin=telemetry')
           ensure
             sleep Puma::Plugin::Telemetry.config.frequency
           end
+        end
+
+        def stop!
+          @stopped = true
+        end
+
+        def stopped?
+          !!@stopped
         end
 
         def call(telemetry)
@@ -99,6 +105,21 @@ module Puma
         end
 
         private
+
+        def setup_runner
+          @launcher.events.on_stopped { stop! }
+
+          in_background do
+            sleep Puma::Plugin::Telemetry.config.initial_delay
+            run!
+          end
+        end
+
+        def publish
+          log_writer.debug 'plugin=telemetry msg="publish"'
+
+          call(Puma::Plugin::Telemetry.build(@launcher))
+        end
 
         def log_writer
           if Puma::Const::PUMA_VERSION.to_i < 6

--- a/spec/puma/plugin/telemetry_spec.rb
+++ b/spec/puma/plugin/telemetry_spec.rb
@@ -52,7 +52,7 @@ module Puma
             end
           end
 
-          let(:launcher) { instance_double(Puma::Launcher, log_writer: log_writer) }
+          let(:launcher) { instance_double(Puma::Launcher, log_writer: log_writer, events: log_writer) }
 
           let(:config) do
             Telemetry::Config.new.tap do |c|

--- a/spec/puma/plugin/telemetry_spec.rb
+++ b/spec/puma/plugin/telemetry_spec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
+require 'puma/events'
+
 module Puma
   class Plugin
     RSpec.describe Telemetry do
@@ -38,6 +42,140 @@ module Puma
         describe 'plugin registration' do
           it 'works' do
             expect(plugin).to respond_to(:start)
+          end
+        end
+
+        describe '#run!' do
+          let(:log_writer) do
+            instance_double(Puma::LogWriter, debug: nil, log: nil, unknown_error: nil).tap do |writer|
+              allow(writer).to receive(:error) { exit(1) }
+            end
+          end
+
+          let(:launcher) { instance_double(Puma::Launcher, log_writer: log_writer) }
+
+          let(:config) do
+            Telemetry::Config.new.tap do |c|
+              c.frequency = 0
+              c.targets = [target]
+            end
+          end
+
+          let(:calls) { [] }
+
+          before do
+            allow(described_class).to receive_messages(config: config, build: {})
+            plugin.instance_variable_set(:@launcher, launcher)
+          end
+
+          context 'when the target raises IOError' do
+            let(:target) do
+              proc do
+                calls << 1
+                raise IOError, 'closed stream'
+              end
+            end
+
+            it 'stops the loop without raising' do
+              expect { Timeout.timeout(1) { plugin.run! } }.not_to raise_error
+            end
+
+            it 'stops publishing' do
+              Timeout.timeout(1) { plugin.run! }
+
+              expect(calls.size).to eq(1)
+            end
+          end
+
+          context 'when the target raises Errno::EPIPE' do
+            let(:target) do
+              proc do
+                calls << 1
+                raise Errno::EPIPE
+              end
+            end
+
+            it 'stops the loop' do
+              Timeout.timeout(1) { plugin.run! }
+
+              expect(calls.size).to eq(1)
+            end
+          end
+
+          context 'when the target raises other StandardError' do
+            let(:target) do
+              proc do
+                calls << 1
+                raise 'boom' if calls.size == 1
+
+                raise IOError, 'closed stream'
+              end
+            end
+
+            it 'logs the error without exiting puma and keeps the loop running' do
+              Timeout.timeout(1) { plugin.run! }
+
+              expect(log_writer).to have_received(:unknown_error)
+                .with(instance_of(RuntimeError), nil, 'plugin=telemetry')
+              expect(calls.size).to eq(2)
+            end
+          end
+
+          context 'when the plugin is stopped' do
+            let(:target) { proc { calls << 1 } }
+
+            it 'does not publish' do
+              plugin.stop!
+
+              Timeout.timeout(1) { plugin.run! }
+
+              expect(calls).to be_empty
+            end
+          end
+        end
+
+        describe '#start' do
+          let(:log_writer) { instance_double(Puma::LogWriter, log: nil) }
+          let(:events) { instance_double(Puma::Events) }
+          let(:launcher) { instance_double(Puma::Launcher, log_writer: log_writer, events: events) }
+
+          let(:config) do
+            Telemetry::Config.new.tap do |c|
+              c.enabled = true
+              c.initial_delay = 0
+            end
+          end
+
+          let(:hooks) { [] }
+
+          before do
+            allow(described_class).to receive(:config).and_return(config)
+            allow(events).to receive(:on_stopped) { |&block| hooks << block }
+            allow(plugin).to receive(:in_background)
+          end
+
+          it 'registers an on_stopped hook' do
+            plugin.start(launcher)
+
+            expect(hooks.size).to eq(1)
+          end
+
+          it 'stops the runner when the hook fires' do
+            plugin.start(launcher)
+
+            hooks.each(&:call)
+
+            expect(plugin).to be_stopped
+          end
+
+          context 'when disabled' do
+            before { config.enabled = false }
+
+            it 'does not register an on_stopped hook' do
+              plugin.start(launcher)
+
+              expect(hooks).to be_empty
+            end
           end
         end
 

--- a/spec/puma/plugin/telemetry_spec.rb
+++ b/spec/puma/plugin/telemetry_spec.rb
@@ -85,6 +85,29 @@ module Puma
 
               expect(calls.size).to eq(1)
             end
+
+            it 'logs that the runner stops' do
+              Timeout.timeout(1) { plugin.run! }
+
+              expect(log_writer).to have_received(:log)
+                .with('plugin=telemetry msg="IO stream closed, stopping the runner"')
+            end
+
+            it 'does not sleep before stopping' do
+              config.frequency = 60
+
+              Timeout.timeout(1) { plugin.run! }
+
+              expect(calls.size).to eq(1)
+            end
+
+            context 'when the log stream is also closed' do
+              before { allow(log_writer).to receive(:log).and_raise(IOError) }
+
+              it 'stops without raising' do
+                expect { Timeout.timeout(1) { plugin.run! } }.not_to raise_error
+              end
+            end
           end
 
           context 'when the target raises Errno::EPIPE' do
@@ -166,6 +189,14 @@ module Puma
             hooks.each(&:call)
 
             expect(plugin).to be_stopped
+          end
+
+          it 'resets a previous stop' do
+            plugin.stop!
+
+            plugin.start(launcher)
+
+            expect(plugin).not_to be_stopped
           end
 
           context 'when disabled' do


### PR DESCRIPTION
## Problem

The telemetry loop keeps publishing while puma shuts down. When the target IO stream is closed before the loop stops, the publish raises `IOError`. The loop rescues only `Errno::EPIPE`, so the `IOError` falls through to `log_writer.error`, which logs:

```
ERROR: plugin=telemetry err=IOError msg="closed stream"
```

and then calls `exit 1` — puma's `LogWriter#error` exits the process. #31 reports this exit behavior: any transient publish error kills the puma master.

## Fix

- Register an `on_stopped` hook that stops the runner loop when puma shuts down.
- Rescue `IOError` next to `Errno::EPIPE` and stop the loop, because the stream does not come back.
- Log other errors with `log_writer.unknown_error`, which does not exit puma.

`Events#on_stopped` and `unknown_error` exist in puma 5 through 8, on both the `events` (puma < 6) and `log_writer` (puma >= 6) paths.

Fixes #31

## Verification

- New unit specs for the runner loop and the stop hook.
- Full suite green on linux (ruby:3.3 docker, 37 examples, 0 failures) and macOS (1 pending: the darwin socket skip).
- RuboCop clean.