### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0]
+
 ### Added
 - New `:open_telemetry` target. Metric names get the `puma` prefix by default. Requires the `opentelemetry-metrics-sdk` gem in the consumer project (#30)
 - New `formatter:` options for the IO target: `:json` and `:passthrough` (#25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-plugin-telemetry (1.1.6)
+    puma-plugin-telemetry (1.2.0)
       puma (< 9)
 
 GEM

--- a/lib/puma/plugin/telemetry/version.rb
+++ b/lib/puma/plugin/telemetry/version.rb
@@ -3,7 +3,7 @@
 module Puma
   class Plugin
     module Telemetry
-      VERSION = '1.1.6'
+      VERSION = '1.2.0'
     end
   end
 end


### PR DESCRIPTION
## Release 1.2.0

Bump the gem version to 1.2.0 and move the Unreleased changelog entries into the 1.2.0 section.

### Included in this release

**Added**
- New `:open_telemetry` target with a default `puma` metric prefix (#30)
- New `formatter:` (`:json`, `:passthrough`) and `transform:` (`:cloud_watch`, `:passthrough`) options for the IO target (#25)

**Changed**
- A custom `formatter:` on the IO target now receives the transformed telemetry; pass `transform: :passthrough` for the old behavior (#25)

**Dropped**
- The `Targets::IOTarget::JSONFormatter` constant (#25)

**Fixed**
- Telemetry runner stops cleanly on puma shutdown; no more `IOError: closed stream` errors, and publish errors no longer make puma exit (#31, #45)
- `socket_telemetry!` warns and stays disabled on platforms without `Socket::SOL_TCP`/`Socket::TCP_INFO` (#23)

### Release steps after merge

1. Tag the merge commit: `git tag v1.2.0 <merge-sha> && git push origin v1.2.0`
2. The tag creation triggers the release job, which publishes the gem to rubygems
3. Create the GitHub release with these notes

Note: the earlier v1.2.0 tag pointed at a commit with version 1.1.6; the release job failed on the rubygems duplicate check and nothing was published. That tag should be deleted before tagging again: `git push origin :refs/tags/v1.2.0`